### PR TITLE
fix auto increment id for pgsql

### DIFF
--- a/database/seeders/WilayaCommuneSeeder.php
+++ b/database/seeders/WilayaCommuneSeeder.php
@@ -50,7 +50,6 @@ class WilayaCommuneSeeder extends Seeder
         $data = [];
         foreach ($wilayas_json as $wilaya) {
             $data[] = [
-                'id'          => $wilaya->id,
                 'name'        => $wilaya->name,
                 'arabic_name' => $wilaya->ar_name,
                 'longitude'   => $wilaya->longitude,
@@ -70,7 +69,6 @@ class WilayaCommuneSeeder extends Seeder
         $data = [];
         foreach ($communes_json as $commune) {
             $data[] = [
-                'id'          => $commune->id,
                 'name'        => $commune->name,
                 'arabic_name' => $commune->ar_name,
                 'post_code'   => $commune->post_code,


### PR DESCRIPTION

  this problem appeared with the pgsl SGBD :
 if you want to add a new wilaya or commune an error has appeared :  **PostgreSQL**: Unique violation: 7 ERROR: duplicate key value violates unique constraint.

**Explication :**  
Postgres handles auto incrementing a little differently than MySQL does. In Postgres, when you create the serial field, you are also creating a sequence field that is keeping track of the id to use. This sequence field is going to start out with a value of 1.

When you insert a new record into the table, if you don't specify the id field, it will use the value of the sequence, and then increment the sequence. However, if you do specify the id field, then the sequence is not used, and it is not updated, either.

I'm assuming that when you moved over to Postgres, you seeded or imported some existing users, along with their existing ids. When you created these user records with their ids, the sequence was not used, and therefore it was never updated.

So, if, for example, you imported 10 users, you have users with ids 1-10, but your sequence is still at 1. When you attempt to create a new user without specifying the id, it pulls the value from the sequence (1), and you get a unique violation because you already have a user with id 1.