### PR TITLE
feature : add API enable/disable configuration for Algerian Cities package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ It provides functionality to load Wilayas (provinces) and Communes (municipaliti
 - Wilaya and Commune Eloquent models with relationships.
 - Supports Arabic and French languages.
 - Includes postal codes and latitude/longitude for each commune.
-- Available as API endpoints.
-- Helper functions for easy integration in Blade views.
+- [Helper functions for easy integration in Blade views](#using-helper-functions).
+- [Available as API endpoints](#using-the-package-as-an-api).
 
 ## Requirements
 
@@ -51,23 +51,14 @@ The package provides two models: `Wilaya` and `Commune`.
 A `Wilaya` has many `Commune`, and you can interact with them just like any other Eloquent models.
 
 ```php
-namespace App;
-
-use Illuminate\Database\Eloquent\Model;
-use Kossa\AlgerianCities\Commune;
-use Kossa\AlgerianCities\Wilaya;
-
-class AnyClass extends Model
-{
-    // Retrieve all Wilayas
-    $wilayas = Wilaya::all();
-
-    // Retrieve all Communes
-    $communes = Commune::all();
-
-    // Get all Communes belonging to Algiers (Wilaya ID: 16)
-    $algiers_communes = Commune::where('wilaya_id', 16)->get();
-}
+// Retrieve all Wilayas
+$wilayas = Wilaya::all();
+    
+// Retrieve all Communes
+$communes = Commune::all();
+    
+// Get all Communes belonging to Algiers (Wilaya ID: 16)
+$algiers_communes = Commune::where('wilaya_id', 16)->get();
 ```
 
 ### Using Helper Functions
@@ -142,6 +133,16 @@ This package includes `api.php` routes, allowing you to interact with the data t
 | GET  | `/api/communes/{id}`         | Retrieve a specific Commune by ID                  |
 | GET  | `/api/search/wilaya/{q}`     | Search Wilayas by name or Arabic name              |
 | GET  | `/api/search/commune/{q}`    | Search Communes by name or Arabic name             |
+
+### API Availability Toggle
+
+You can enable or disable the Algerian Cities API endpoints by setting the following option in your `.env` file:
+
+```dotenv
+ALGERIAN_CITIES_API_ENABLED=false # Default: true
+```
+
+----
 
 ## Future Planned Features
 

--- a/config/algerian-cities.php
+++ b/config/algerian-cities.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    /**
+     * Enable or disable the Algerian Cities API
+     */
+    'api_enabled' => env('ALGERIAN_CITIES_API_ENABLED', true),
+];

--- a/src/Providers/AlgerianCitiesServiceProvider.php
+++ b/src/Providers/AlgerianCitiesServiceProvider.php
@@ -31,8 +31,14 @@ class AlgerianCitiesServiceProvider extends ServiceProvider
             ]);
         }
 
-        // API
-        $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
+        // Config file
+        $this->publishes([
+            __DIR__.'/../../config/algerian-cities.php' => config_path('algerian-cities.php'),
+        ], 'config');
+
+        if(config('algerian-cities.use_routes', true)) {
+            $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
+        }
 
         require __DIR__.'/../helpers.php';
     }
@@ -50,8 +56,8 @@ class AlgerianCitiesServiceProvider extends ServiceProvider
          * Uncomment this function call to load the config file.
          * If the config file is also publishable, it will merge with that file
          */
-        // $this->mergeConfigFrom(
-        //     __DIR__.'/../../config/algerian-cities.php', 'algerian-cities'
-        // );
+         $this->mergeConfigFrom(
+             __DIR__.'/../../config/algerian-cities.php', 'algerian-cities'
+         );
     }
 }

--- a/src/Providers/AlgerianCitiesServiceProvider.php
+++ b/src/Providers/AlgerianCitiesServiceProvider.php
@@ -36,7 +36,7 @@ class AlgerianCitiesServiceProvider extends ServiceProvider
             __DIR__.'/../../config/algerian-cities.php' => config_path('algerian-cities.php'),
         ], 'config');
 
-        if(config('algerian-cities.use_routes', true)) {
+        if (config('algerian-cities.use_routes', true)) {
             $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
         }
 
@@ -56,8 +56,8 @@ class AlgerianCitiesServiceProvider extends ServiceProvider
          * Uncomment this function call to load the config file.
          * If the config file is also publishable, it will merge with that file
          */
-         $this->mergeConfigFrom(
-             __DIR__.'/../../config/algerian-cities.php', 'algerian-cities'
-         );
+        $this->mergeConfigFrom(
+            __DIR__.'/../../config/algerian-cities.php', 'algerian-cities'
+        );
     }
 }

--- a/src/Providers/AlgerianCitiesServiceProvider.php
+++ b/src/Providers/AlgerianCitiesServiceProvider.php
@@ -36,7 +36,7 @@ class AlgerianCitiesServiceProvider extends ServiceProvider
             __DIR__.'/../../config/algerian-cities.php' => config_path('algerian-cities.php'),
         ], 'config');
 
-        if (config('algerian-cities.use_routes', true)) {
+        if (config('algerian-cities.api_enabled')) {
             $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Kossa\AlgerianCities\Tests;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 
@@ -14,7 +15,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 {
     use RefreshDatabase;
 
-    public function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app): void
     {
         $CreateCitiesTable = include __DIR__.'/../database/migrations/2024_10_26_000000_create_cities_table.php.stub';
 
@@ -26,13 +27,10 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     /**
      * Include the package's service provider(s)
-     *
-     * @see https://packages.tools/testbench/basic/testcase.html#package-service-providers
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return array
+     **
+     * @param  Application  $app
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             \Kossa\AlgerianCities\Providers\AlgerianCitiesServiceProvider::class,


### PR DESCRIPTION
This PR introduces an `api_enabled` configuration for the Algerian Cities package, allowing users to enable or disable API endpoints via the `.env` file. 

### Changes

- Added config variable `ALGERIAN_CITIES_API_ENABLED` to toggle API access for the Algerian Cities package.
  
### Usage

To enable or disable the API, add the following to your `.env` file:
```dotenv
ALGERIAN_CITIES_API_ENABLED=true  # or false
```

### Related Issues
#16 