### PR TITLE
Extend CI Workflow for PHP 8.4 & Stability Testing; Add Larastan ^3.0 Support

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
+        stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
   ],
   "homepage": "https://github.com/kossa/algerian-cities",
   "require": {
-    "php": "^8.1|^8.2|^8.3",
+    "php": "^8.1",
     "laravel/framework": "^10.0|^11.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0|^11.0",
     "orchestra/testbench": "^8.0|^9.0",
     "laravel/pint": "^1.18",
-    "larastan/larastan": "^2.0"
+    "larastan/larastan": "^2.0|^3.0"
   },
   "license": "MIT",
   "autoload": {


### PR DESCRIPTION
- Added testing for PHP 8.4 in CI workflow.  
- Included `prefer-lowest` and `prefer-stable` stability options.  
- Updated development dependencies to support Larastan ^3.0.  
Ensures broader compatibility and keeps the project aligned with the latest tools.  