### PR TITLE
Set PHPStan to Maximum Level

### DIFF
--- a/baseline-8.1.neon
+++ b/baseline-8.1.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Kossa\\\\AlgerianCities\\\\Commune\\:\\:wilaya\\(\\) should return Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo\\<Kossa\\\\AlgerianCities\\\\Wilaya, \\$this\\(Kossa\\\\AlgerianCities\\\\Commune\\)\\> but returns Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\BelongsTo\\<Kossa\\\\AlgerianCities\\\\Wilaya, Kossa\\\\AlgerianCities\\\\Commune\\>\\.$#"
+			count: 1
+			path: src/Commune.php
+
+		-
+			message: "#^Generic type Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<Kossa\\\\AlgerianCities\\\\Commune, \\$this\\(Kossa\\\\AlgerianCities\\\\Wilaya\\)\\> in PHPDoc tag @return specifies 2 template types, but class Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany supports only 1\\: TRelatedModel$#"
+			count: 1
+			path: src/Wilaya.php
+
+		-
+			message: "#^Method Kossa\\\\AlgerianCities\\\\Wilaya\\:\\:communes\\(\\) should return Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<Kossa\\\\AlgerianCities\\\\Commune, \\$this\\(Kossa\\\\AlgerianCities\\\\Wilaya\\)\\> but returns Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\<Kossa\\\\AlgerianCities\\\\Commune\\>\\.$#"
+			count: 1
+			path: src/Wilaya.php

--- a/database/seeders/WilayaCommuneSeeder.php
+++ b/database/seeders/WilayaCommuneSeeder.php
@@ -12,10 +12,8 @@ class WilayaCommuneSeeder extends Seeder
 {
     /**
      * Run the database seeds.
-     *
-     * @return void
      */
-    public function run()
+    public function run(): void
     {
         // Check if table exist
         if (! Schema::hasTable('wilayas') || ! Schema::hasTable('communes')) {
@@ -35,13 +33,13 @@ class WilayaCommuneSeeder extends Seeder
         $this->command->comment('Wilayas/Communes already loaded');
     }
 
-    protected function loadData()
+    protected function loadData(): void
     {
         $this->insertWilayas();
         $this->insertCommunes();
     }
 
-    protected function insertWilayas()
+    protected function insertWilayas(): void
     {
         // Load wilayas from json
         try {
@@ -63,7 +61,7 @@ class WilayaCommuneSeeder extends Seeder
         DB::table('wilayas')->insert($data);
     }
 
-    protected function insertCommunes()
+    protected function insertCommunes(): void
     {
         // Load wilayas from json
         try {

--- a/ignore-by-php-version.neon.php
+++ b/ignore-by-php-version.neon.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+$includes = [];
+
+if (PHP_VERSION_ID < 80200) {
+    $includes[] = __DIR__.'/baseline-8.1.neon';
+}
+
+$config = [];
+$config['includes'] = $includes;
+$config['parameters']['phpVersion'] = PHP_VERSION_ID;
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 includes:
     - vendor/larastan/larastan/extension.neon
 parameters:
-    level: 5
+    level: max
     paths:
         - src/
         - tests/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - vendor/larastan/larastan/extension.neon
+    - ignore-by-php-version.neon.php
 parameters:
     level: max
     paths:

--- a/src/Commune.php
+++ b/src/Commune.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Kossa\AlgerianCities;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -14,12 +16,12 @@ class Commune extends Model
 {
     protected $fillable = ['name', 'arabic_name', 'post_code', 'wilaya_id', 'longitude', 'latitude'];
 
-    /*
-    |------------------------------------------------------------------------------------
-    | Validations
-    |------------------------------------------------------------------------------------
-    */
-    public static function rules($update = false, $id = null): array
+    /**
+     * Validation rules
+     *
+     * @return array<string, string>
+     */
+    public static function rules(): array
     {
         return [
             'name' => 'required',
@@ -27,18 +29,19 @@ class Commune extends Model
         ];
     }
 
-    /*
-    |------------------------------------------------------------------------------------
-    | Relations
-    |------------------------------------------------------------------------------------
-    */
-    public function scopeWithWilaya($q, $name = 'name'): void
+    /**
+     * @param  Builder<Wilaya>  $query
+     */
+    public function scopeWithWilaya(Builder $query, string $name = 'name'): void
     {
-        $q->leftJoin('wilayas', 'wilayas.id', 'communes.wilaya_id')
+        $query->leftJoin('wilayas', 'wilayas.id', 'communes.wilaya_id')
             ->select('communes.id', DB::raw(sprintf("concat(communes.%s, ', ', wilayas.%s) as name", $name, $name)));
     }
 
-    public function wilaya()
+    /**
+     * @return BelongsTo<Wilaya, $this>
+     */
+    public function wilaya(): BelongsTo
     {
         return $this->belongsTo(Wilaya::class)->withDefault();
     }
@@ -48,7 +51,7 @@ class Commune extends Model
     | Attribute
     |------------------------------------------------------------------------------------
     */
-    public function getWilayaNameAttribute()
+    public function getWilayaNameAttribute(): string
     {
         return $this->wilaya->name;
     }

--- a/src/Controllers/Api/CommuneController.php
+++ b/src/Controllers/Api/CommuneController.php
@@ -4,24 +4,25 @@ declare(strict_types=1);
 
 namespace Kossa\AlgerianCities\Controllers\Api;
 
+use Illuminate\Database\Eloquent\Collection;
 use Kossa\AlgerianCities\Commune;
 
 class CommuneController
 {
     /**
      * Get all Communes.
+     *
+     * @return Collection<int, Commune>
      */
-    public function index()
+    public function index(): Collection
     {
         return Commune::all();
     }
 
     /**
      * Get a specified Commune.
-     *
-     * @param  int  $id
      */
-    public function show($id)
+    public function show(int $id): Commune
     {
         return Commune::findOrFail($id);
     }
@@ -30,8 +31,9 @@ class CommuneController
      * Search wilaya by name or arabic_name
      *
      * @param  string  $q
+     * @return Collection<int, Commune>
      */
-    public function search($q)
+    public function search($q): Collection
     {
         return Commune::where('name', 'like', sprintf('%%%s%%', $q))
             ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $q))

--- a/src/Controllers/Api/CommuneController.php
+++ b/src/Controllers/Api/CommuneController.php
@@ -30,13 +30,12 @@ class CommuneController
     /**
      * Search wilaya by name or arabic_name
      *
-     * @param  string  $q
      * @return Collection<int, Commune>
      */
-    public function search($q): Collection
+    public function search(string $keyword): Collection
     {
-        return Commune::where('name', 'like', sprintf('%%%s%%', $q))
-            ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $q))
+        return Commune::where('name', 'like', sprintf('%%%s%%', $keyword))
+            ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $keyword))
             ->get();
     }
 }

--- a/src/Controllers/Api/WilayaController.php
+++ b/src/Controllers/Api/WilayaController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kossa\AlgerianCities\Controllers\Api;
 
+use Illuminate\Database\Eloquent\Collection;
 use Kossa\AlgerianCities\Commune;
 use Kossa\AlgerianCities\Wilaya;
 
@@ -11,18 +12,18 @@ class WilayaController
 {
     /**
      * Get all wilayas.
+     *
+     * @return Collection<int, Wilaya>
      */
-    public function index()
+    public function index(): Collection
     {
         return Wilaya::all();
     }
 
     /**
      * Get a specified Wilaya.
-     *
-     * @param  int  $id
      */
-    public function show($id)
+    public function show(int $id): Wilaya
     {
         return Wilaya::findOrFail($id);
     }
@@ -30,9 +31,9 @@ class WilayaController
     /**
      * Get communes of wilayas_id.
      *
-     * @param  int  $id
+     * @return Collection<int, Commune>
      */
-    public function communes($id)
+    public function communes(int $id): Collection
     {
         return Commune::where('wilaya_id', $id)->get();
     }
@@ -40,9 +41,9 @@ class WilayaController
     /**
      * Search wilaya by name or arabic_name
      *
-     * @param  string  $q
+     * @return Collection<int, Wilaya>
      */
-    public function search($q)
+    public function search(string $q): Collection
     {
         return Wilaya::where('name', 'like', sprintf('%%%s%%', $q))
             ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $q))

--- a/src/Controllers/Api/WilayaController.php
+++ b/src/Controllers/Api/WilayaController.php
@@ -43,10 +43,10 @@ class WilayaController
      *
      * @return Collection<int, Wilaya>
      */
-    public function search(string $q): Collection
+    public function search(string $keyword): Collection
     {
-        return Wilaya::where('name', 'like', sprintf('%%%s%%', $q))
-            ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $q))
+        return Wilaya::where('name', 'like', sprintf('%%%s%%', $keyword))
+            ->orWhere('arabic_name', 'like', sprintf('%%%s%%', $keyword))
             ->get();
     }
 }

--- a/src/Wilaya.php
+++ b/src/Wilaya.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kossa\AlgerianCities;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property string $name
@@ -13,24 +14,22 @@ class Wilaya extends Model
 {
     protected $fillable = ['name', 'arabic_name', 'longitude', 'latitude'];
 
-    /*
-    |------------------------------------------------------------------------------------
-    | Validations
-    |------------------------------------------------------------------------------------
-    */
-    public static function rules($update = false, $id = null): array
+    /**
+     * Validation rules
+     *
+     * @return array<string, string>
+     */
+    public static function rules(): array
     {
         return [
             'name' => 'required',
         ];
     }
 
-    /*
-    |------------------------------------------------------------------------------------
-    | Relations
-    |------------------------------------------------------------------------------------
-    */
-    public function communes()
+    /**
+     * @return HasMany<Commune, $this>
+     */
+    public function communes(): HasMany
     {
         return $this->hasMany(Commune::class);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,11 +10,9 @@ if (! function_exists('communes')) {
     /**
      * Get list of communes
      *
-     * @param  int|null  $wilaya_id  wilaya_id the id of wilaya
-     * @param  bool  $withWilaya  withWilaya if you need to include the wilaya
-     * @param  string  $name  name the default name user arabic_name to get arabic name
+     * @return array<mixed>
      */
-    function communes(?int $wilaya_id = null, bool $withWilaya = false, $name = 'name'): array
+    function communes(?int $wilaya_id = null, bool $withWilaya = false, string $name = 'name'): array
     {
         $communes = Commune::query();
 
@@ -35,7 +33,7 @@ if (! function_exists('wilayas')) {
     /**
      * Get list of wilayas
      *
-     * @param  string  $name  default name use arabic_name to get wilayas in arabic
+     * @return array<mixed>
      */
     function wilayas(string $name = 'name'): array
     {
@@ -47,11 +45,8 @@ if (! function_exists('commune')) {
 
     /**
      * Get single commune
-     *
-     * @param  int  $id  id The ID of commune
-     * @param  bool  $withWilaya  withWilaya True if you need to include wilaya
      */
-    function commune(int $id, bool $withWilaya = false)
+    function commune(int $id, bool $withWilaya = false): Commune
     {
         $commune = Commune::findOrFail($id);
 
@@ -67,10 +62,8 @@ if (! function_exists('wilaya')) {
 
     /**
      * Get single wilaya
-     *
-     * @param  int  $id  id The ID of wilaya
-     */
-    function wilaya($id)
+     **/
+    function wilaya(int $id): Wilaya
     {
         return wilaya::findOrFail($id);
     }

--- a/tests/CommuneTest.php
+++ b/tests/CommuneTest.php
@@ -16,7 +16,7 @@ final class CommuneTest extends TestCase
     public function test_if_commune_details_are_correct(): void
     {
         $sampleCommune = Commune::where('name', 'Alger Centre')
-            ->first(['id', 'name', 'arabic_name', 'post_code', 'longitude', 'latitude']);
+            ->firstOrFail(['id', 'name', 'arabic_name', 'post_code', 'longitude', 'latitude']);
 
         $this->assertJsonStringEqualsJsonString(
             $sampleCommune->toJson(),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,8 +21,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         $CreateCitiesTable = include __DIR__.'/../database/migrations/2024_10_26_000000_create_cities_table.php.stub';
 
-        // run the migration's up() method
-        $CreateCitiesTable->up();
+        assert($CreateCitiesTable instanceof \Illuminate\Database\Migrations\Migration);
+
+        if (method_exists($CreateCitiesTable, 'up')) {
+            $CreateCitiesTable->up();
+        }
 
         Artisan::call('db:seed', ['--class' => 'WilayaCommuneSeeder']);
     }

--- a/tests/WilayaTest.php
+++ b/tests/WilayaTest.php
@@ -15,7 +15,7 @@ final class WilayaTest extends TestCase
 
     public function test_if_wilaya_details_are_correct(): void
     {
-        $sampleWilaya = Wilaya::where('name', 'Alger')->first(['id', 'name', 'arabic_name', 'longitude', 'latitude']);
+        $sampleWilaya = Wilaya::where('name', 'Alger')->firstOrFail(['id', 'name', 'arabic_name', 'longitude', 'latitude']);
         $this->assertJsonStringEqualsJsonString(
             $sampleWilaya->toJson(),
             '{"id":16,"name":"Alger","arabic_name":"الجزائر","longitude":36.753768,"latitude":3.0587561}'


### PR DESCRIPTION
This PR increases the PHPStan analysis level to `max`, ensuring stricter static analysis and improved code quality for the. 

#### Changes
- **Set PHPStan level to `max`** in `phpstan.neon`
- **Added PHPStan baseline for PHP 8.1** to handle known errors
- **Updated method signatures** to include explicit return types
- **Refactored models and controllers**:
  - Added type hints for method parameters and return types
  - Improved PHPDoc annotations for better static analysis
- **Fixed test cases**:
  - Used `firstOrFail()` instead of `first()` for stricter data validation
  - Added assertions to ensure consistency with test expectations
- **Introduced compatibility handling**:
  - Added `ignore-by-php-version.neon.php` to manage PHP version-specific errors

#### Benefits
- Enforces stricter type safety and code quality
- Reduces potential runtime errors by catching issues earlier
- Improves maintainability and consistency of the codebase
